### PR TITLE
Fixed project URL

### DIFF
--- a/src/OdeToCode.AddFeatureFolders/project.json
+++ b/src/OdeToCode.AddFeatureFolders/project.json
@@ -6,10 +6,10 @@
   "packOptions": {
     "tags": [ "feature folders", "asp.net core" ],
     "licenseUrl": "https://raw.githubusercontent.com/OdeToCode/AddFeatureFolders/master/LICENSE",
-    "projectUrl": "https://raw.githubusercontent.com/OdeToCode/AddFeatureFolders/",
+    "projectUrl": "https://github.com/OdeToCode/AddFeatureFolders/",
     "repository": {
       "type": "git",
-      "url": "https://raw.githubusercontent.com/OdeToCode/AddFeatureFolders/"
+      "url": "https://github.com/OdeToCode/AddFeatureFolders/"
     }
   },
 


### PR DESCRIPTION
Project link on NuGet leads to 400: Invalid request message.

Really enjoyed your .NET Rocks interview by the way 👍 